### PR TITLE
Minor fixes

### DIFF
--- a/FaultTriggering/Examples/ActuatorExample/ActuatorPackageStatistics.mo
+++ b/FaultTriggering/Examples/ActuatorExample/ActuatorPackageStatistics.mo
@@ -46,7 +46,7 @@ ActuatorPackageStatistics.Interfaces.Faults faults
     annotation (Placement(transformation(extent={{-40,-80},{-20,-60}})));
   Modelica.Blocks.Sources.Constant failureRateDrivelineBearing(k=0.1)
     annotation (Placement(transformation(extent={{-80,-80},{-60,-60}})));
-  inner Modelica_Noise.Blocks.Noise.GlobalSeed globalSeed(useAutomaticSeed=true)
+  inner Modelica.Blocks.Noise.GlobalSeed globalSeed(useAutomaticSeed=true)
     annotation (Placement(transformation(extent={{60,60},{80,80}})));
 equation
 realFault[1] = faults.driveline.friction.externalRealFault;

--- a/FaultTriggering/FaultOutput/Partial_FaultTrigger.mo
+++ b/FaultTriggering/FaultOutput/Partial_FaultTrigger.mo
@@ -2,11 +2,11 @@ within FaultTriggering.FaultOutput;
 partial model Partial_FaultTrigger "partial model defining the fault classes"
   extends FaultTriggering.Utilities.Icons.FaultModel;
   parameter Integer realFaultSize(    min=0)=0
-    "Number of real fault channels in the model"                                            annotation(Dialog(enable = tue, tab = "Advanced"));
+    "Number of real fault channels in the model"                                            annotation(Dialog(enable = true, tab = "Advanced"));
   parameter Integer integerFaultSize( min=0)=0
-    "Number of integer fault channels in the model"                                            annotation(Dialog(enable = tue, tab = "Advanced"));
+    "Number of integer fault channels in the model"                                            annotation(Dialog(enable = true, tab = "Advanced"));
   parameter Integer booleanFaultSize( min=0)=0
-    "Number of boolean fault channels in the model"                                            annotation(Dialog(enable = tue, tab = "Advanced"));
+    "Number of boolean fault channels in the model"                                            annotation(Dialog(enable = true, tab = "Advanced"));
 
   Real    realFault[realFaultSize] "Real Fault trigger";
   Integer integerFault[integerFaultSize] "Integer Fault trigger";

--- a/FaultTriggering/package.mo
+++ b/FaultTriggering/package.mo
@@ -11,7 +11,7 @@ package FaultTriggering "Library for Fault Triggering"
 
 
 
-  annotation (uses(Modelica(version="3.2.2")),
+  annotation (uses(Modelica(version="3.2.2"),AdvancedNoise(version="1.0.0")),
     version="0.6.6", conversion(from(version="0.6.4", to="0.6.5", script="modelica://FaultTriggering/Resources/Scripts/Convert_from_0.6.4_to_0.6.5.mos")),
     versionDate="2015-07-15",
 preferredView="info",


### PR DESCRIPTION
The following has been changed to fix errors in _Dymola 2018_:
 * outdated `Modelica_Noise` reference
 * misspelled `enable = tue` for `Dialog` annotation
 * uses reference to _AdvancedNoise 1.0.0_

The changes are downwards compatible and also required by older _Dymola_ versions and other _Modelica_ IDEs.